### PR TITLE
fix: remove prerelease versioning

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,12 +10,12 @@ import (
 
 var (
 	// Version is the main version number that is being run at the moment.
-	Version = "2.0.0"
+	Version = "2.0.1"
 
 	// VersionPrerelease is A pre-release marker for the Version. If this is ""
 	// (empty string) then it means that it is a final release. Otherwise, this
 	// is a pre-release such as "dev" (in development), "beta", "rc1", etc.
-	VersionPrerelease = "dev"
+	VersionPrerelease = ""
 
 	// PluginVersion is used by the plugin set to allow Packer to recognize
 	// what version this plugin is.


### PR DESCRIPTION
More recent versions of packer compare the version number output by the plugin via the `describe` command with the filename, and if they don't match it fails. This has broken our AMI builds because the plugin reports a prerelease version (`2.0.0-dev`), but the filename version is just `2.0.0`.